### PR TITLE
Add Menu state with input handling and rendering

### DIFF
--- a/SFMLGame/BackMenuOption.cpp
+++ b/SFMLGame/BackMenuOption.cpp
@@ -5,7 +5,8 @@ using namespace NAMESPACE;
 using namespace std;
 
 BackMenuOption::BackMenuOption( shared_ptr<GameStateController> stateController ) :
-   _stateController( stateController )
+   _stateController( stateController ),
+   _text( "Back" )
 {
 }
 

--- a/SFMLGame/BackMenuOption.cpp
+++ b/SFMLGame/BackMenuOption.cpp
@@ -1,0 +1,15 @@
+#include "BackMenuOption.h"
+#include "GameStateController.h"
+
+using namespace NAMESPACE;
+using namespace std;
+
+BackMenuOption::BackMenuOption( shared_ptr<GameStateController> stateController ) :
+   _stateController( stateController )
+{
+}
+
+void BackMenuOption::Select()
+{
+   _stateController->SetState( GameState::Playing );
+}

--- a/SFMLGame/BackMenuOption.h
+++ b/SFMLGame/BackMenuOption.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Common.h"
+#include "IMenuOption.h"
+
+NAMESPACE_BEGIN
+
+class GameStateController;
+
+class BackMenuOption : public IMenuOption
+{
+public:
+   BackMenuOption( std::shared_ptr<GameStateController> stateController );
+
+   // IMenuOption
+   std::string GetText() const override { return _text; }
+   void Select() override;
+
+private:
+   std::shared_ptr<GameStateController> _stateController;
+
+   std::string _text;
+};
+
+NAMESPACE_END

--- a/SFMLGame/Button.h
+++ b/SFMLGame/Button.h
@@ -7,6 +7,12 @@ NAMESPACE_BEGIN
 enum class Button
 {
    Back = 0,
+   Action,
+
+   Left,
+   Up,
+   Right,
+   Down,
 
    Diagnostics,
 

--- a/SFMLGame/GameConfig.cpp
+++ b/SFMLGame/GameConfig.cpp
@@ -40,6 +40,10 @@ GameConfig::GameConfig()
    DiagnosticsTextColor = sf::Color::White;
    DiagnosticsBackgroundColor = sf::Color::Blue;
 
+   MessageFont = "consolas.ttf";
+   MessageCharSize = 32;
+   MessageTextColor = sf::Color::White;
+
    MenuFont = "consolas.ttf";
    MenuCharSize = 32;
    MenuTextColor = sf::Color::White;

--- a/SFMLGame/GameConfig.cpp
+++ b/SFMLGame/GameConfig.cpp
@@ -39,4 +39,10 @@ GameConfig::GameConfig()
    DiagnosticsCharSize = 24;
    DiagnosticsTextColor = sf::Color::White;
    DiagnosticsBackgroundColor = sf::Color::Blue;
+
+   MenuFont = "consolas.ttf";
+   MenuCharSize = 32;
+   MenuTextColor = sf::Color::White;
+   MenuCaratOffset = 20;
+   MenuCaratBlinkRate = 0.2f;
 }

--- a/SFMLGame/GameConfig.cpp
+++ b/SFMLGame/GameConfig.cpp
@@ -20,6 +20,11 @@ GameConfig::GameConfig()
    KeyBindingsMap =
    {
       { KeyCode::Escape, Button::Back },
+      { KeyCode::Return, Button::Action },
+      { KeyCode::Left, Button::Left },
+      { KeyCode::Up, Button::Up },
+      { KeyCode::Right, Button::Right },
+      { KeyCode::Down, Button::Down },
       { KeyCode::F12, Button::Diagnostics }
    };
 

--- a/SFMLGame/GameConfig.h
+++ b/SFMLGame/GameConfig.h
@@ -39,6 +39,12 @@ public:
    unsigned int DiagnosticsCharSize;
    sf::Color DiagnosticsTextColor;
    sf::Color DiagnosticsBackgroundColor;
+
+   std::string MenuFont;
+   unsigned int MenuCharSize;
+   sf::Color MenuTextColor;
+   float MenuCaratOffset;
+   float MenuCaratBlinkRate;
 };
 
 NAMESPACE_END

--- a/SFMLGame/GameConfig.h
+++ b/SFMLGame/GameConfig.h
@@ -40,6 +40,10 @@ public:
    sf::Color DiagnosticsTextColor;
    sf::Color DiagnosticsBackgroundColor;
 
+   std::string MessageFont;
+   unsigned int MessageCharSize;
+   sf::Color MessageTextColor;
+
    std::string MenuFont;
    unsigned int MenuCharSize;
    sf::Color MenuTextColor;

--- a/SFMLGame/GameLoader.cpp
+++ b/SFMLGame/GameLoader.cpp
@@ -4,6 +4,9 @@
 #include "GameClock.h"
 #include "KeyboardInputReader.h"
 #include "GameStateController.h"
+#include "BackMenuOption.h"
+#include "QuitMenuOption.h"
+#include "Menu.h"
 #include "PlayingStateInputHandler.h"
 #include "MenuStateInputHandler.h"
 #include "GameInputHandler.h"
@@ -25,8 +28,13 @@ shared_ptr<Game> GameLoader::Load()
    auto clock = shared_ptr<GameClock>( new GameClock( config ) );
    auto inputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( config ) );
    auto stateController = make_shared<GameStateController>();
-   auto playingStateInputHandler = shared_ptr<PlayingStateInputHandler>( new PlayingStateInputHandler( inputReader, eventAggregator ) );
-   auto menuStateInputHandler = shared_ptr<MenuStateInputHandler>( new MenuStateInputHandler( inputReader ) );
+   auto backMenuOption = shared_ptr<BackMenuOption>( new BackMenuOption( stateController ) );
+   auto quitMenuOption = shared_ptr<QuitMenuOption>( new QuitMenuOption( eventAggregator ) );
+   auto menu = make_shared<Menu>();
+   menu->AddOption( backMenuOption );
+   menu->AddOption( quitMenuOption );
+   auto playingStateInputHandler = shared_ptr<PlayingStateInputHandler>( new PlayingStateInputHandler( inputReader, stateController ) );
+   auto menuStateInputHandler = shared_ptr<MenuStateInputHandler>( new MenuStateInputHandler( inputReader, stateController, menu ) );
    auto gameInputHandler = shared_ptr<GameInputHandler>( new GameInputHandler( config, inputReader, stateController ) );
    gameInputHandler->AddStateInputHandler( GameState::Playing, playingStateInputHandler );
    gameInputHandler->AddStateInputHandler( GameState::Menu, menuStateInputHandler );

--- a/SFMLGame/GameLoader.cpp
+++ b/SFMLGame/GameLoader.cpp
@@ -10,6 +10,7 @@
 #include "GameLogic.h"
 #include "DiagnosticsRenderer.h"
 #include "PlayingStateRenderer.h"
+#include "MenuStateRenderer.h"
 #include "SFMLWindow.h"
 #include "GameRenderer.h"
 #include "Game.h"
@@ -33,8 +34,10 @@ shared_ptr<Game> GameLoader::Load()
    auto window = shared_ptr<SFMLWindow>( new SFMLWindow( config, eventAggregator, clock ) );
    auto diagnosticRenderer = shared_ptr<DiagnosticsRenderer>( new DiagnosticsRenderer( config, clock, window ) );
    auto playingStateRenderer = shared_ptr<PlayingStateRenderer>( new PlayingStateRenderer() );
+   auto menuStateRenderer = shared_ptr<MenuStateRenderer>( new MenuStateRenderer() );
    auto gameRenderer = shared_ptr<GameRenderer>( new GameRenderer( config, window, diagnosticRenderer, stateController ) );
    gameRenderer->AddStateRenderer( GameState::Playing, playingStateRenderer );
+   gameRenderer->AddStateRenderer( GameState::Menu, menuStateRenderer );
    auto game = shared_ptr<Game>( new Game( eventAggregator, clock, inputReader, logic, gameRenderer ) );
 
    return game;

--- a/SFMLGame/GameLoader.cpp
+++ b/SFMLGame/GameLoader.cpp
@@ -5,6 +5,7 @@
 #include "KeyboardInputReader.h"
 #include "GameStateController.h"
 #include "PlayingStateInputHandler.h"
+#include "MenuStateInputHandler.h"
 #include "GameInputHandler.h"
 #include "GameLogic.h"
 #include "DiagnosticsRenderer.h"
@@ -24,8 +25,10 @@ shared_ptr<Game> GameLoader::Load()
    auto inputReader = shared_ptr<KeyboardInputReader>( new KeyboardInputReader( config ) );
    auto stateController = make_shared<GameStateController>();
    auto playingStateInputHandler = shared_ptr<PlayingStateInputHandler>( new PlayingStateInputHandler( inputReader, eventAggregator ) );
+   auto menuStateInputHandler = shared_ptr<MenuStateInputHandler>( new MenuStateInputHandler( inputReader ) );
    auto gameInputHandler = shared_ptr<GameInputHandler>( new GameInputHandler( config, inputReader, stateController ) );
    gameInputHandler->AddStateInputHandler( GameState::Playing, playingStateInputHandler );
+   gameInputHandler->AddStateInputHandler( GameState::Menu, menuStateInputHandler );
    auto logic = shared_ptr<GameLogic>( new GameLogic( gameInputHandler ) );
    auto window = shared_ptr<SFMLWindow>( new SFMLWindow( config, eventAggregator, clock ) );
    auto diagnosticRenderer = shared_ptr<DiagnosticsRenderer>( new DiagnosticsRenderer( config, clock, window ) );

--- a/SFMLGame/GameLoader.cpp
+++ b/SFMLGame/GameLoader.cpp
@@ -42,7 +42,7 @@ shared_ptr<Game> GameLoader::Load()
    auto window = shared_ptr<SFMLWindow>( new SFMLWindow( config, eventAggregator, clock ) );
    auto diagnosticRenderer = shared_ptr<DiagnosticsRenderer>( new DiagnosticsRenderer( config, clock, window ) );
    auto playingStateRenderer = shared_ptr<PlayingStateRenderer>( new PlayingStateRenderer() );
-   auto menuStateRenderer = shared_ptr<MenuStateRenderer>( new MenuStateRenderer() );
+   auto menuStateRenderer = shared_ptr<MenuStateRenderer>( new MenuStateRenderer( config, window, clock, menu ) );
    auto gameRenderer = shared_ptr<GameRenderer>( new GameRenderer( config, window, diagnosticRenderer, stateController ) );
    gameRenderer->AddStateRenderer( GameState::Playing, playingStateRenderer );
    gameRenderer->AddStateRenderer( GameState::Menu, menuStateRenderer );

--- a/SFMLGame/GameLoader.cpp
+++ b/SFMLGame/GameLoader.cpp
@@ -41,7 +41,7 @@ shared_ptr<Game> GameLoader::Load()
    auto logic = shared_ptr<GameLogic>( new GameLogic( gameInputHandler ) );
    auto window = shared_ptr<SFMLWindow>( new SFMLWindow( config, eventAggregator, clock ) );
    auto diagnosticRenderer = shared_ptr<DiagnosticsRenderer>( new DiagnosticsRenderer( config, clock, window ) );
-   auto playingStateRenderer = shared_ptr<PlayingStateRenderer>( new PlayingStateRenderer() );
+   auto playingStateRenderer = shared_ptr<PlayingStateRenderer>( new PlayingStateRenderer( config, window ) );
    auto menuStateRenderer = shared_ptr<MenuStateRenderer>( new MenuStateRenderer( config, window, clock, menu ) );
    auto gameRenderer = shared_ptr<GameRenderer>( new GameRenderer( config, window, diagnosticRenderer, stateController ) );
    gameRenderer->AddStateRenderer( GameState::Playing, playingStateRenderer );

--- a/SFMLGame/GameState.h
+++ b/SFMLGame/GameState.h
@@ -6,7 +6,8 @@ NAMESPACE_BEGIN
 
 enum class GameState
 {
-   Playing = 0
+   Playing = 0,
+   Menu
 };
 
 NAMESPACE_END

--- a/SFMLGame/IMenuOption.h
+++ b/SFMLGame/IMenuOption.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+#include "Common.h"
+
+NAMESPACE_BEGIN
+
+class __declspec( novtable ) IMenuOption
+{
+public:
+   virtual std::string GetText() const = 0;
+   virtual void Select() = 0;
+};
+
+NAMESPACE_END

--- a/SFMLGame/Menu.cpp
+++ b/SFMLGame/Menu.cpp
@@ -1,0 +1,35 @@
+#include "Menu.h"
+#include "IMenuOption.h"
+
+using namespace NAMESPACE;
+using namespace std;
+
+void Menu::AddOption( std::shared_ptr<IMenuOption> option )
+{
+   _options.push_back( option );
+}
+
+void Menu::ScrollUp()
+{
+   _currentOptionIndex--;
+
+   if ( _currentOptionIndex < 0 )
+   {
+      _currentOptionIndex = (int)_options.size() - 1;
+   }
+}
+
+void Menu::ScrollDown()
+{
+   _currentOptionIndex++;
+
+   if ( _currentOptionIndex >= (int)_options.size() )
+   {
+      _currentOptionIndex = 0;
+   }
+}
+
+void Menu::SelectCurrentOption() const
+{
+   _options[_currentOptionIndex]->Select();
+}

--- a/SFMLGame/Menu.h
+++ b/SFMLGame/Menu.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <vector>
+
+#include "Common.h"
+
+NAMESPACE_BEGIN
+
+class IMenuOption;
+
+class Menu
+{
+public:
+   void AddOption( std::shared_ptr<IMenuOption> option );
+   int GetOptionCount() const { return (int)_options.size(); }
+   std::shared_ptr<IMenuOption> GetOptionByIndex( int index ) const { return _options[index]; }
+   int GetCurrentOptionIndex() const { return _currentOptionIndex; }
+   void ScrollUp();
+   void ScrollDown();
+   void SelectCurrentOption() const;
+
+private:
+   std::vector<std::shared_ptr<IMenuOption>> _options;
+   int _currentOptionIndex;
+};
+
+NAMESPACE_END

--- a/SFMLGame/MenuStateInputHandler.cpp
+++ b/SFMLGame/MenuStateInputHandler.cpp
@@ -1,11 +1,17 @@
 #include "MenuStateInputHandler.h"
 #include "IInputReader.h"
+#include "GameStateController.h"
+#include "Menu.h"
 
 using namespace NAMESPACE;
 using namespace std;
 
-MenuStateInputHandler::MenuStateInputHandler( shared_ptr<IInputReader> inputReader ) :
-   _inputReader( inputReader )
+MenuStateInputHandler::MenuStateInputHandler( shared_ptr<IInputReader> inputReader,
+                                              shared_ptr<GameStateController> stateController,
+                                              shared_ptr<Menu> menu ) :
+   _inputReader( inputReader ),
+   _stateController( stateController ),
+   _menu( menu )
 {
 }
 
@@ -13,18 +19,18 @@ void MenuStateInputHandler::HandleInput()
 {
    if ( _inputReader->WasButtonPressed( Button::Back ) )
    {
-      // TOOD: go back to Playing state
+      _stateController->SetState( GameState::Playing );
    }
    else if ( _inputReader->WasButtonPressed( Button::Up ) )
    {
-      // TODO: scroll up
+      _menu->ScrollUp();
    }
    else if ( _inputReader->WasButtonPressed( Button::Down ) )
    {
-      // TODO: scroll down
+      _menu->ScrollDown();
    }
    else if ( _inputReader->WasButtonPressed( Button::Action ) )
    {
-      // TODO: select menu option
+      _menu->SelectCurrentOption();
    }
 }

--- a/SFMLGame/MenuStateInputHandler.cpp
+++ b/SFMLGame/MenuStateInputHandler.cpp
@@ -1,0 +1,30 @@
+#include "MenuStateInputHandler.h"
+#include "IInputReader.h"
+
+using namespace NAMESPACE;
+using namespace std;
+
+MenuStateInputHandler::MenuStateInputHandler( shared_ptr<IInputReader> inputReader ) :
+   _inputReader( inputReader )
+{
+}
+
+void MenuStateInputHandler::HandleInput()
+{
+   if ( _inputReader->WasButtonPressed( Button::Back ) )
+   {
+      // TOOD: go back to Playing state
+   }
+   else if ( _inputReader->WasButtonPressed( Button::Up ) )
+   {
+      // TODO: scroll up
+   }
+   else if ( _inputReader->WasButtonPressed( Button::Down ) )
+   {
+      // TODO: scroll down
+   }
+   else if ( _inputReader->WasButtonPressed( Button::Action ) )
+   {
+      // TODO: select menu option
+   }
+}

--- a/SFMLGame/MenuStateInputHandler.h
+++ b/SFMLGame/MenuStateInputHandler.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Common.h"
+#include "IGameStateInputHandler.h"
+
+NAMESPACE_BEGIN
+
+class IInputReader;
+
+class MenuStateInputHandler : public IGameStateInputHandler
+{
+public:
+   MenuStateInputHandler( std::shared_ptr<IInputReader> inputReader );
+
+   // IGameStateInputHandler
+   void HandleInput() override;
+
+private:
+   std::shared_ptr<IInputReader> _inputReader;
+};
+
+NAMESPACE_END

--- a/SFMLGame/MenuStateInputHandler.h
+++ b/SFMLGame/MenuStateInputHandler.h
@@ -6,17 +6,24 @@
 NAMESPACE_BEGIN
 
 class IInputReader;
+class GameStateController;
+class Menu;
 
 class MenuStateInputHandler : public IGameStateInputHandler
 {
 public:
-   MenuStateInputHandler( std::shared_ptr<IInputReader> inputReader );
+   MenuStateInputHandler( std::shared_ptr<IInputReader> inputReader,
+                          std::shared_ptr<GameStateController> stateController,
+                          std::shared_ptr<Menu> menu );
 
    // IGameStateInputHandler
    void HandleInput() override;
 
 private:
    std::shared_ptr<IInputReader> _inputReader;
+   std::shared_ptr<GameStateController> _stateController;
+
+   std::shared_ptr<Menu> _menu;
 };
 
 NAMESPACE_END

--- a/SFMLGame/MenuStateRenderer.cpp
+++ b/SFMLGame/MenuStateRenderer.cpp
@@ -1,0 +1,8 @@
+#include "MenuStateRenderer.h"
+
+using namespace NAMESPACE;
+
+void MenuStateRenderer::Render()
+{
+   // TODO: render the menu
+}

--- a/SFMLGame/MenuStateRenderer.cpp
+++ b/SFMLGame/MenuStateRenderer.cpp
@@ -1,8 +1,83 @@
+#include <SFML/Graphics.hpp>
+
 #include "MenuStateRenderer.h"
+#include "GameConfig.h"
+#include "SFMLWindow.h"
+#include "GameClock.h"
+#include "Menu.h"
+#include "IMenuOption.h"
 
 using namespace NAMESPACE;
+using namespace std;
+using namespace sf;
+
+MenuStateRenderer::MenuStateRenderer( shared_ptr<GameConfig> config,
+                                      shared_ptr<SFMLWindow> window,
+                                      shared_ptr<GameClock> clock,
+                                      shared_ptr<Menu> menu ) :
+   _config( config ),
+   _window( window ),
+   _clock( clock ),
+   _menu( menu ),
+   _elapsedSeconds( 0 ),
+   _showCarat( true )
+{
+   _font = make_shared<Font>();
+   _font->loadFromFile( config->MenuFont );
+
+   _text = make_shared<Text>();
+   _text->setFont( *_font );
+   _text->setCharacterSize( config->MenuCharSize );
+   _text->setFillColor( config->MenuTextColor );
+
+   _carat = make_shared<Text>();
+   _carat->setFont( *_font );
+   _carat->setCharacterSize( config->MenuCharSize );
+   _carat->setFillColor( config->MenuTextColor );
+   _carat->setString( ">" );
+
+   _lineSpacing = _font->getLineSpacing( _text->getCharacterSize() );
+
+   string menuText = "";
+
+   for ( int i = 0; i < menu->GetOptionCount(); i++ )
+   {
+      if ( i > 0 )
+      {
+         menuText += "\n";
+      }
+
+      menuText += menu->GetOptionByIndex( i )->GetText();
+   }
+
+   _text->setString( menuText );
+
+   auto textWidth = _text->getGlobalBounds().width;
+   auto caratWidth = _carat->getGlobalBounds().width;
+   auto menuWidth = textWidth + caratWidth + config->MenuCaratOffset;
+   auto menuHeight = menu->GetOptionCount() * _lineSpacing;
+
+   _menuX = ( config->ScreenWidth / 2 ) - ( menuWidth / 2 );
+   _menuY = ( config->ScreenHeight / 2 ) - ( menuHeight / 2 );
+
+   _text->setPosition( _menuX + caratWidth + config->MenuCaratOffset, _menuY );
+}
 
 void MenuStateRenderer::Render()
 {
-   // TODO: render the menu
+   _elapsedSeconds += _clock->GetFrameSeconds();
+
+   if ( _elapsedSeconds >= _config->MenuCaratBlinkRate )
+   {
+      _elapsedSeconds = 0;
+      _showCarat = !_showCarat;
+   }
+
+   _window->Draw( _text );
+
+   if ( _showCarat )
+   {
+      _carat->setPosition( _menuX, _menuY + ( _menu->GetCurrentOptionIndex() * _lineSpacing ) );
+      _window->Draw( _carat );
+   }
 }

--- a/SFMLGame/MenuStateRenderer.h
+++ b/SFMLGame/MenuStateRenderer.h
@@ -3,13 +3,47 @@
 #include "Common.h"
 #include "IGameStateRenderer.h"
 
+namespace sf
+{
+   class Font;
+   class Text;
+   class RectangleShape;
+}
+
 NAMESPACE_BEGIN
+
+class GameConfig;
+class SFMLWindow;
+class GameClock;
+class Menu;
 
 class MenuStateRenderer : public IGameStateRenderer
 {
 public:
+   MenuStateRenderer( std::shared_ptr<GameConfig> config,
+                      std::shared_ptr<SFMLWindow> window,
+                      std::shared_ptr<GameClock> clock,
+                      std::shared_ptr<Menu> menu );
+
    // IGameStateRenderer
    void Render() override;
+
+private:
+   std::shared_ptr<GameConfig> _config;
+   std::shared_ptr<SFMLWindow> _window;
+   std::shared_ptr<GameClock> _clock;
+   std::shared_ptr<Menu> _menu;
+
+   std::shared_ptr<sf::Font> _font;
+   std::shared_ptr<sf::Text> _text;
+   std::shared_ptr<sf::Text> _carat;
+
+   float _menuX;
+   float _menuY;
+   float _lineSpacing;
+
+   float _elapsedSeconds;
+   bool _showCarat;
 };
 
 NAMESPACE_END

--- a/SFMLGame/MenuStateRenderer.h
+++ b/SFMLGame/MenuStateRenderer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Common.h"
+#include "IGameStateRenderer.h"
+
+NAMESPACE_BEGIN
+
+class MenuStateRenderer : public IGameStateRenderer
+{
+public:
+   // IGameStateRenderer
+   void Render() override;
+};
+
+NAMESPACE_END

--- a/SFMLGame/PlayingStateInputHandler.cpp
+++ b/SFMLGame/PlayingStateInputHandler.cpp
@@ -1,14 +1,14 @@
 #include "PlayingStateInputHandler.h"
 #include "IInputReader.h"
-#include "EventAggregator.h"
+#include "GameStateController.h"
 
 using namespace NAMESPACE;
 using namespace std;
 
 PlayingStateInputHandler::PlayingStateInputHandler( shared_ptr<IInputReader> inputReader,
-                                                    shared_ptr<EventAggregator> eventAggregator ) :
+                                                    shared_ptr<GameStateController> stateController ) :
    _inputReader( inputReader ),
-   _eventAggregator( eventAggregator )
+   _stateController( stateController )
 {
 }
 
@@ -16,6 +16,6 @@ void PlayingStateInputHandler::HandleInput()
 {
    if ( _inputReader->WasButtonPressed( Button::Back ) )
    {
-      _eventAggregator->RaiseEvent( GameEvent::Quit );
+      _stateController->SetState( GameState::Menu );
    }
 }

--- a/SFMLGame/PlayingStateInputHandler.h
+++ b/SFMLGame/PlayingStateInputHandler.h
@@ -6,20 +6,20 @@
 NAMESPACE_BEGIN
 
 class IInputReader;
-class EventAggregator;
+class GameStateController;
 
 class PlayingStateInputHandler : public IGameStateInputHandler
 {
 public:
    PlayingStateInputHandler( std::shared_ptr<IInputReader> inputReader,
-                             std::shared_ptr<EventAggregator> eventAggregator );
+                             std::shared_ptr<GameStateController> stateController );
 
    // IGameStateInputHandler
    void HandleInput() override;
 
 private:
    std::shared_ptr<IInputReader> _inputReader;
-   std::shared_ptr<EventAggregator> _eventAggregator;
+   std::shared_ptr<GameStateController> _stateController;
 };
 
 NAMESPACE_END

--- a/SFMLGame/PlayingStateRenderer.cpp
+++ b/SFMLGame/PlayingStateRenderer.cpp
@@ -1,8 +1,31 @@
+#include <SFML/Graphics.hpp>
+
 #include "PlayingStateRenderer.h"
+#include "GameConfig.h"
+#include "SFMLWindow.h"
 
 using namespace NAMESPACE;
+using namespace std;
+using namespace sf;
+
+PlayingStateRenderer::PlayingStateRenderer( shared_ptr<GameConfig> config,
+                                            shared_ptr<SFMLWindow> window ) :
+   _window( window )
+{
+   _font = make_shared<Font>();
+   _font->loadFromFile( config->MessageFont );
+
+   _text = make_shared<Text>();
+   _text->setFont( *_font );
+   _text->setCharacterSize( config->MessageCharSize );
+   _text->setFillColor( config->MessageTextColor );
+   _text->setString( "Press ESC for menu, or F12 to toggle diagnostics" );
+
+   _text->setPosition( ( config->ScreenWidth / 2 ) - ( _text->getGlobalBounds().width / 2 ),
+                       ( config->ScreenHeight / 2 ) - ( _text->getGlobalBounds().height / 2 ) );
+}
 
 void PlayingStateRenderer::Render()
 {
-   // TODO: render the game
+   _window->Draw( _text );
 }

--- a/SFMLGame/PlayingStateRenderer.h
+++ b/SFMLGame/PlayingStateRenderer.h
@@ -3,13 +3,32 @@
 #include "Common.h"
 #include "IGameStateRenderer.h"
 
+namespace sf
+{
+   class Font;
+   class Text;
+   class RectangleShape;
+}
+
 NAMESPACE_BEGIN
+
+class GameConfig;
+class SFMLWindow;
 
 class PlayingStateRenderer : public IGameStateRenderer
 {
 public:
+   PlayingStateRenderer( std::shared_ptr<GameConfig> config,
+                         std::shared_ptr<SFMLWindow> window );
+
    // IGameStateRenderer
    void Render() override;
+
+private:
+   std::shared_ptr<SFMLWindow> _window;
+
+   std::shared_ptr<sf::Font> _font;
+   std::shared_ptr<sf::Text> _text;
 };
 
 NAMESPACE_END

--- a/SFMLGame/QuitMenuOption.cpp
+++ b/SFMLGame/QuitMenuOption.cpp
@@ -5,7 +5,8 @@ using namespace NAMESPACE;
 using namespace std;
 
 QuitMenuOption::QuitMenuOption( shared_ptr<EventAggregator> eventAggregator ) :
-   _eventAggregator( eventAggregator )
+   _eventAggregator( eventAggregator ),
+   _text( "Quit" )
 {
 }
 

--- a/SFMLGame/QuitMenuOption.cpp
+++ b/SFMLGame/QuitMenuOption.cpp
@@ -1,0 +1,15 @@
+#include "QuitMenuOption.h"
+#include "EventAggregator.h"
+
+using namespace NAMESPACE;
+using namespace std;
+
+QuitMenuOption::QuitMenuOption( shared_ptr<EventAggregator> eventAggregator ) :
+   _eventAggregator( eventAggregator )
+{
+}
+
+void QuitMenuOption::Select()
+{
+   _eventAggregator->RaiseEvent( GameEvent::Quit );
+}

--- a/SFMLGame/QuitMenuOption.h
+++ b/SFMLGame/QuitMenuOption.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Common.h"
+#include "IMenuOption.h"
+
+NAMESPACE_BEGIN
+
+class EventAggregator;
+
+class QuitMenuOption : public IMenuOption
+{
+public:
+   QuitMenuOption( std::shared_ptr<EventAggregator> eventAggregator );
+
+   // IMenuOption
+   std::string GetText() const override { return _text; }
+   void Select() override;
+
+private:
+   std::shared_ptr<EventAggregator> _eventAggregator;
+
+   std::string _text;
+};
+
+NAMESPACE_END

--- a/SFMLGame/SFMLGame.vcxproj
+++ b/SFMLGame/SFMLGame.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="KeyboardInputReader.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="MenuStateInputHandler.cpp" />
+    <ClCompile Include="MenuStateRenderer.cpp" />
     <ClCompile Include="PlayingStateInputHandler.cpp" />
     <ClCompile Include="PlayingStateRenderer.cpp" />
     <ClCompile Include="SFMLWindow.cpp" />
@@ -197,6 +198,7 @@
     <ClInclude Include="KeyCode.h" />
     <ClInclude Include="Common.h" />
     <ClInclude Include="MenuStateInputHandler.h" />
+    <ClInclude Include="MenuStateRenderer.h" />
     <ClInclude Include="PlayingStateInputHandler.h" />
     <ClInclude Include="PlayingStateRenderer.h" />
     <ClInclude Include="SFMLWindow.h" />

--- a/SFMLGame/SFMLGame.vcxproj
+++ b/SFMLGame/SFMLGame.vcxproj
@@ -169,6 +169,7 @@
     <ClCompile Include="GameInputHandler.cpp" />
     <ClCompile Include="KeyboardInputReader.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="MenuStateInputHandler.cpp" />
     <ClCompile Include="PlayingStateInputHandler.cpp" />
     <ClCompile Include="PlayingStateRenderer.cpp" />
     <ClCompile Include="SFMLWindow.cpp" />
@@ -195,6 +196,7 @@
     <ClInclude Include="KeyboardInputReader.h" />
     <ClInclude Include="KeyCode.h" />
     <ClInclude Include="Common.h" />
+    <ClInclude Include="MenuStateInputHandler.h" />
     <ClInclude Include="PlayingStateInputHandler.h" />
     <ClInclude Include="PlayingStateRenderer.h" />
     <ClInclude Include="SFMLWindow.h" />

--- a/SFMLGame/SFMLGame.vcxproj
+++ b/SFMLGame/SFMLGame.vcxproj
@@ -157,6 +157,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="BackMenuOption.cpp" />
     <ClCompile Include="DiagnosticsRenderer.cpp" />
     <ClCompile Include="EventAggregator.cpp" />
     <ClCompile Include="Game.cpp" />
@@ -169,13 +170,16 @@
     <ClCompile Include="GameInputHandler.cpp" />
     <ClCompile Include="KeyboardInputReader.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="Menu.cpp" />
     <ClCompile Include="MenuStateInputHandler.cpp" />
     <ClCompile Include="MenuStateRenderer.cpp" />
     <ClCompile Include="PlayingStateInputHandler.cpp" />
     <ClCompile Include="PlayingStateRenderer.cpp" />
+    <ClCompile Include="QuitMenuOption.cpp" />
     <ClCompile Include="SFMLWindow.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="BackMenuOption.h" />
     <ClInclude Include="Button.h" />
     <ClInclude Include="ButtonState.h" />
     <ClInclude Include="DiagnosticsRenderer.h" />
@@ -194,13 +198,16 @@
     <ClInclude Include="IGameStateRenderer.h" />
     <ClInclude Include="IInputReader.h" />
     <ClInclude Include="GameInputHandler.h" />
+    <ClInclude Include="IMenuOption.h" />
     <ClInclude Include="KeyboardInputReader.h" />
     <ClInclude Include="KeyCode.h" />
     <ClInclude Include="Common.h" />
+    <ClInclude Include="Menu.h" />
     <ClInclude Include="MenuStateInputHandler.h" />
     <ClInclude Include="MenuStateRenderer.h" />
     <ClInclude Include="PlayingStateInputHandler.h" />
     <ClInclude Include="PlayingStateRenderer.h" />
+    <ClInclude Include="QuitMenuOption.h" />
     <ClInclude Include="SFMLWindow.h" />
     <ClInclude Include="WindowsLibs.h" />
   </ItemGroup>

--- a/SFMLGame/SFMLGame.vcxproj.filters
+++ b/SFMLGame/SFMLGame.vcxproj.filters
@@ -49,6 +49,12 @@
     <Filter Include="Source Files\Game">
       <UniqueIdentifier>{f3f538df-ceef-4189-b6de-bc36df6b74c6}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Menu">
+      <UniqueIdentifier>{48e6180d-86e8-4d51-9d11-2ae2f62996b7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Menu">
+      <UniqueIdentifier>{891632fd-cad5-4cbe-85ec-6304429bcddd}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -101,6 +107,15 @@
     </ClCompile>
     <ClCompile Include="MenuStateRenderer.cpp">
       <Filter>Source Files\Rendering</Filter>
+    </ClCompile>
+    <ClCompile Include="QuitMenuOption.cpp">
+      <Filter>Source Files\Menu</Filter>
+    </ClCompile>
+    <ClCompile Include="Menu.cpp">
+      <Filter>Source Files\Menu</Filter>
+    </ClCompile>
+    <ClCompile Include="BackMenuOption.cpp">
+      <Filter>Source Files\Menu</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -184,6 +199,18 @@
     </ClInclude>
     <ClInclude Include="MenuStateRenderer.h">
       <Filter>Header Files\Rendering</Filter>
+    </ClInclude>
+    <ClInclude Include="IMenuOption.h">
+      <Filter>Header Files\Menu</Filter>
+    </ClInclude>
+    <ClInclude Include="QuitMenuOption.h">
+      <Filter>Header Files\Menu</Filter>
+    </ClInclude>
+    <ClInclude Include="Menu.h">
+      <Filter>Header Files\Menu</Filter>
+    </ClInclude>
+    <ClInclude Include="BackMenuOption.h">
+      <Filter>Header Files\Menu</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/SFMLGame/SFMLGame.vcxproj.filters
+++ b/SFMLGame/SFMLGame.vcxproj.filters
@@ -84,6 +84,21 @@
     <ClCompile Include="GameLogic.cpp">
       <Filter>Source Files\Game</Filter>
     </ClCompile>
+    <ClCompile Include="GameInputHandler.cpp">
+      <Filter>Source Files\Input</Filter>
+    </ClCompile>
+    <ClCompile Include="GameStateController.cpp">
+      <Filter>Source Files\Game</Filter>
+    </ClCompile>
+    <ClCompile Include="MenuStateInputHandler.cpp">
+      <Filter>Source Files\Input</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayingStateInputHandler.cpp">
+      <Filter>Source Files\Input</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayingStateRenderer.cpp">
+      <Filter>Source Files\Rendering</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Button.h">
@@ -139,6 +154,30 @@
     </ClInclude>
     <ClInclude Include="GameLogic.h">
       <Filter>Header Files\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="GameInputHandler.h">
+      <Filter>Header Files\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="GameState.h">
+      <Filter>Header Files\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="GameStateController.h">
+      <Filter>Header Files\Game</Filter>
+    </ClInclude>
+    <ClInclude Include="IGameStateInputHandler.h">
+      <Filter>Header Files\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="IGameStateRenderer.h">
+      <Filter>Header Files\Rendering</Filter>
+    </ClInclude>
+    <ClInclude Include="MenuStateInputHandler.h">
+      <Filter>Header Files\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="PlayingStateInputHandler.h">
+      <Filter>Header Files\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="PlayingStateRenderer.h">
+      <Filter>Header Files\Rendering</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/SFMLGame/SFMLGame.vcxproj.filters
+++ b/SFMLGame/SFMLGame.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClCompile Include="PlayingStateRenderer.cpp">
       <Filter>Source Files\Rendering</Filter>
     </ClCompile>
+    <ClCompile Include="MenuStateRenderer.cpp">
+      <Filter>Source Files\Rendering</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Button.h">
@@ -177,6 +180,9 @@
       <Filter>Header Files\Input</Filter>
     </ClInclude>
     <ClInclude Include="PlayingStateRenderer.h">
+      <Filter>Header Files\Rendering</Filter>
+    </ClInclude>
+    <ClInclude Include="MenuStateRenderer.h">
       <Filter>Header Files\Rendering</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This adds a new GameState value: `Menu`. It also adds an input handler, renderer, and a couple menu options as examples. I thought about not adding a state, and doing something like allowing each state to have its own menu, but it seemed more flexible to do it this way, so if you wanted multiple menus for any given state you could add multiple states, like `PlayingMainMenu`, `PlayingCharacterMenu`, `PlayingStatsMenu`, etc.