### PR TITLE
Add missing strings to string table

### DIFF
--- a/SFMLGame/BackMenuOption.cpp
+++ b/SFMLGame/BackMenuOption.cpp
@@ -6,7 +6,7 @@ using namespace std;
 
 BackMenuOption::BackMenuOption( shared_ptr<GameData> gameData ) :
    _gameData( gameData ),
-   _text( "Back" )
+   _text( IDS_MenuOptionBack )
 {
 }
 

--- a/SFMLGame/QuitMenuOption.cpp
+++ b/SFMLGame/QuitMenuOption.cpp
@@ -6,7 +6,7 @@ using namespace std;
 
 QuitMenuOption::QuitMenuOption( shared_ptr<EventAggregator> eventAggregator ) :
    _eventAggregator( eventAggregator ),
-   _text( "Quit" )
+   _text( IDS_MenuOptionQuit )
 {
 }
 

--- a/SFMLGame/StringTable.h
+++ b/SFMLGame/StringTable.h
@@ -18,3 +18,7 @@
 
 // playing state
 #define IDS_PlayStateMessage        "Press ESC for menu, or F12 to toggle diagnostics"
+
+// menu
+#define IDS_MenuOptionBack          "Back"
+#define IDS_MenuOptionQuit          "Quit"


### PR DESCRIPTION
## Overview

In my last PR I forgot to add the menu strings to the string table, so this just adds "Back" and "Quit".