### PR TITLE
Fix issues with clock inconsistencies

### DIFF
--- a/SFMLGame/DiagnosticsRenderer.cpp
+++ b/SFMLGame/DiagnosticsRenderer.cpp
@@ -42,6 +42,7 @@ void DiagnosticsRenderer::Render()
    static string text;
    text = "";
 
+   text += format( IDS_MinimumFrameRate, _renderConfig->MinimumFrameRate ) + "\n";
    text += format( IDS_MaximumFrameRate, _renderConfig->MaximumFrameRate ) + "\n";
    text += format( IDS_CurrentFrameRate, _clock->GetCurrentFrameRate() ) + "\n";
    text += format( IDS_AverageFrameRate, _clock->GetAverageFrameRate() ) + "\n";

--- a/SFMLGame/DiagnosticsRenderer.cpp
+++ b/SFMLGame/DiagnosticsRenderer.cpp
@@ -1,4 +1,5 @@
 #include <format>
+#include <chrono>
 
 #include "DiagnosticsRenderer.h"
 #include "RenderConfig.h"
@@ -45,7 +46,8 @@ void DiagnosticsRenderer::Render()
    text += format( IDS_CurrentFrameRate, _clock->GetCurrentFrameRate() ) + "\n";
    text += format( IDS_AverageFrameRate, _clock->GetAverageFrameRate() ) + "\n";
    text += format( IDS_TotalFrames, _clock->GetTotalFrameCount() ) + "\n";
-   text += format( IDS_LagFrames, _clock->GetLagFrameCount() ) + "\n\n";
+   text += format( IDS_LagFrames, _clock->GetLagFrameCount() ) + "\n";
+   text += format( IDS_TotalElapsedTime, chrono::round<chrono::seconds>( chrono::duration<float>{ _clock->GetTotalElapsedSeconds() } ) ) + "\n\n";
 
    auto ball = _gameData->GetBall();
    text += format( IDS_BallAngle, ball->GetAngle() ) + "\n";

--- a/SFMLGame/DiagnosticsRenderer.h
+++ b/SFMLGame/DiagnosticsRenderer.h
@@ -2,13 +2,6 @@
 
 #include "Common.h"
 
-namespace sf
-{
-   class Font;
-   class Text;
-   class RectangleShape;
-}
-
 NAMESPACE_BEGIN
 
 class RenderConfig;

--- a/SFMLGame/Game.cpp
+++ b/SFMLGame/Game.cpp
@@ -32,7 +32,6 @@ void Game::Run()
    _gameRunningTracker->isRunning = true;
 
    _renderer->Initialize();
-   _clock->Initialize();
 
    while ( _gameRunningTracker->isRunning )
    {

--- a/SFMLGame/GameClock.h
+++ b/SFMLGame/GameClock.h
@@ -10,29 +10,31 @@ class GameClock
 {
 public:
    GameClock( std::shared_ptr<RenderConfig> renderConfig );
-   ~GameClock();
 
-   void Initialize();
    void StartFrame();
    void EndFrame();
 
-   float GetFrameSeconds() const;
-   long long GetTotalFrameCount() const { return _totalFrameCount; }
-   long long GetLagFrameCount() const { return _lagFrameCount; }
-   long long GetElapsedNanoseconds() const { return _totalDurationNano; }
-   long long GetAverageFrameRate() const;
-   long long GetCurrentFrameRate() const;
+   unsigned int GetTotalFrameCount() const { return _totalFrameCount; }
+   unsigned int GetLagFrameCount() const { return _lagFrameCount; }
+   unsigned int GetAverageFrameRate() const;
+   unsigned int GetCurrentFrameRate() const;
+
+   float GetFrameSeconds() const { return _lastFrameSeconds; }
+   float GetTotalElapsedSeconds() const { return _totalElapsedSeconds; }
 
 private:
-   long long _minNanoSecondsPerFrame;
-   long long _maxNanoSecondsPerFrame;
-   long long _totalFrameCount;
-   long long _lagFrameCount;
-   long long _absoluteStartTimeNano;
-   long long _frameStartTimeNano;
-   long long _lastFrameDurationNano;
-   long long _totalDurationNano;
-   bool _wasLagFrame;
+   sf::Clock _clock;
+
+   sf::Time _minFrameDuration;
+   sf::Time _maxFrameDuration;
+
+   unsigned int _totalFrameCount;
+   unsigned int _lagFrameCount;
+
+   sf::Time _frameStartTime;
+
+   float _lastFrameSeconds;
+   float _totalElapsedSeconds;
 };
 
 NAMESPACE_END

--- a/SFMLGame/MainMenuStateRenderer.h
+++ b/SFMLGame/MainMenuStateRenderer.h
@@ -3,13 +3,6 @@
 #include "Common.h"
 #include "IGameStateRenderer.h"
 
-namespace sf
-{
-   class Font;
-   class Text;
-   class RectangleShape;
-}
-
 NAMESPACE_BEGIN
 
 class GameConfig;

--- a/SFMLGame/RenderConfig.cpp
+++ b/SFMLGame/RenderConfig.cpp
@@ -16,7 +16,7 @@ RenderConfig::RenderConfig()
    WindowStyle = Style::Titlebar | Style::Close;
 
    DiagnosticsWidth = 450;
-   DiagnosticsHeight = 265;
+   DiagnosticsHeight = 290;
    DiagnosticsXPosition = ScreenWidth - DiagnosticsWidth;
    DiagnosticsYPosition = 0;
    DiagnosticsTextMargin = 20;

--- a/SFMLGame/RenderConfig.cpp
+++ b/SFMLGame/RenderConfig.cpp
@@ -16,7 +16,7 @@ RenderConfig::RenderConfig()
    WindowStyle = Style::Titlebar | Style::Close;
 
    DiagnosticsWidth = 450;
-   DiagnosticsHeight = 290;
+   DiagnosticsHeight = 320;
    DiagnosticsXPosition = ScreenWidth - DiagnosticsWidth;
    DiagnosticsYPosition = 0;
    DiagnosticsTextMargin = 20;

--- a/SFMLGame/RenderConfig.h
+++ b/SFMLGame/RenderConfig.h
@@ -10,8 +10,8 @@ public:
    RenderConfig();
 
 public:
-   long long MinimumFrameRate;
-   long long MaximumFrameRate;
+   unsigned int MinimumFrameRate;
+   unsigned int MaximumFrameRate;
 
    int ScreenWidth;
    int ScreenHeight;

--- a/SFMLGame/SFMLWindow.h
+++ b/SFMLGame/SFMLWindow.h
@@ -2,12 +2,6 @@
 
 #include "Common.h"
 
-namespace sf
-{
-   class RenderWindow;
-   class Drawable;
-}
-
 NAMESPACE_BEGIN
 
 class RenderConfig;

--- a/SFMLGame/StringTable.h
+++ b/SFMLGame/StringTable.h
@@ -10,6 +10,7 @@
 #define IDS_WindowTitle             "SFML Game"
 
 // diagnostics window
+#define IDS_MinimumFrameRate        "Minimum Frame Rate: {}"
 #define IDS_MaximumFrameRate        "Maximum Frame Rate: {}"
 #define IDS_CurrentFrameRate        "Current Frame Rate: {}"
 #define IDS_AverageFrameRate        "Average Frame Rate: {}"

--- a/SFMLGame/StringTable.h
+++ b/SFMLGame/StringTable.h
@@ -15,6 +15,7 @@
 #define IDS_AverageFrameRate        "Average Frame Rate: {}"
 #define IDS_TotalFrames             "Total Frames:       {}"
 #define IDS_LagFrames               "Lag Frames:         {}"
+#define IDS_TotalElapsedTime        "Total Elapsed Time: {:%T}"
 #define IDS_BallAngle               "Ball Angle:         {}"
 #define IDS_BallVelocity            "Ball Velocity:      {}"
 


### PR DESCRIPTION
## Overview

Turns out sleeping a thread is SUPER unreliable on Windows, no matter which library is used. If you push the frame rate extremely high, `GameClock` somehow reports extremely low frame durations, and vice versa, all because of the sleep function. To mitigate this, I decided to use SFML's built-in clock, but still not rely on the sleep function. Instead, we'll only attempt to sleep, but then after the sleep we'll use the actual clock time to calculate the frame's duration.