### PR TITLE
Immediately show the menu carat when switching options

### DIFF
--- a/SFMLGame/MainMenuStateRenderer.cpp
+++ b/SFMLGame/MainMenuStateRenderer.cpp
@@ -24,6 +24,7 @@ MainMenuStateRenderer::MainMenuStateRenderer( shared_ptr<GameConfig> gameConfig,
    _window( window ),
    _clock( clock ),
    _menu( menu ),
+   _currentOptionIndexCache( 0 ),
    _elapsedSeconds( 0 ),
    _showCarat( true )
 {
@@ -84,7 +85,16 @@ void MainMenuStateRenderer::Render()
    _ballSprite.setPosition( _gameData->GetBall()->GetPosition() );
    _window->Draw( _ballSprite );
 
-   _elapsedSeconds += _clock->GetFrameSeconds();
+   if ( _menu->GetCurrentOptionIndex() != _currentOptionIndexCache )
+   {
+      _currentOptionIndexCache = _menu->GetCurrentOptionIndex();
+      _showCarat = true;
+      _elapsedSeconds = 0;
+   }
+   else
+   {
+      _elapsedSeconds += _clock->GetFrameSeconds();
+   }
 
    if ( _elapsedSeconds >= _renderConfig->MainMenuCaratBlinkRate )
    {
@@ -96,7 +106,7 @@ void MainMenuStateRenderer::Render()
 
    if ( _showCarat )
    {
-      _carat->setPosition( _menuX, _menuY + ( _menu->GetCurrentOptionIndex() * _lineSpacing ) );
+      _carat->setPosition( _menuX, _menuY + ( _currentOptionIndexCache * _lineSpacing ) );
       _window->Draw( _carat );
    }
 }

--- a/SFMLGame/MainMenuStateRenderer.h
+++ b/SFMLGame/MainMenuStateRenderer.h
@@ -44,6 +44,7 @@ private:
    float _menuY;
    float _lineSpacing;
 
+   int _currentOptionIndexCache;
    float _elapsedSeconds;
    bool _showCarat;
 

--- a/SFMLGame/TitleMenuStateRenderer.cpp
+++ b/SFMLGame/TitleMenuStateRenderer.cpp
@@ -16,6 +16,7 @@ TitleMenuStateRenderer::TitleMenuStateRenderer( shared_ptr<RenderConfig> renderC
    _window( window ),
    _clock( clock ),
    _menu( menu ),
+   _currentOptionIndexCache( 0 ),
    _elapsedSeconds( 0 ),
    _showCarat( true )
 {
@@ -67,7 +68,16 @@ void TitleMenuStateRenderer::Render()
 {
    _window->Draw( _backgroundRect );
 
-   _elapsedSeconds += _clock->GetFrameSeconds();
+   if ( _menu->GetCurrentOptionIndex() != _currentOptionIndexCache )
+   {
+      _currentOptionIndexCache = _menu->GetCurrentOptionIndex();
+      _showCarat = true;
+      _elapsedSeconds = 0;
+   }
+   else
+   {
+      _elapsedSeconds += _clock->GetFrameSeconds();
+   }
 
    if ( _elapsedSeconds >= _renderConfig->TitleMenuCaratBlinkRate )
    {

--- a/SFMLGame/TitleMenuStateRenderer.h
+++ b/SFMLGame/TitleMenuStateRenderer.h
@@ -37,6 +37,7 @@ private:
    float _menuY;
    float _lineSpacing;
 
+   int _currentOptionIndexCache;
    float _elapsedSeconds;
    bool _showCarat;
 };


### PR DESCRIPTION
## Overview

If you change to a new menu option, the carat should immediately be visible, even if it was previously on an invisible frame.