### PR TITLE
Add refresh rate for diagnostics current frame rate

### DIFF
--- a/SFMLGame/DiagnosticsRenderer.cpp
+++ b/SFMLGame/DiagnosticsRenderer.cpp
@@ -19,7 +19,9 @@ DiagnosticsRenderer::DiagnosticsRenderer( shared_ptr<RenderConfig> renderConfig,
    _renderConfig( renderConfig ),
    _gameData( gameData ),
    _clock( clock ),
-   _window( window )
+   _window( window ),
+   _currentFrameRateCache( 0 ),
+   _elapsedSeconds( 0 )
 {
    _font = make_shared<Font>();
    _font->loadFromFile( renderConfig->DiagnosticsFont );
@@ -39,12 +41,20 @@ DiagnosticsRenderer::DiagnosticsRenderer( shared_ptr<RenderConfig> renderConfig,
 
 void DiagnosticsRenderer::Render()
 {
+   _elapsedSeconds += _clock->GetFrameSeconds();
+
+   if ( _elapsedSeconds >= _renderConfig->DiagnosticsCurrentFrameRateRefreshSeconds )
+   {
+      _currentFrameRateCache = _clock->GetCurrentFrameRate();
+      _elapsedSeconds = 0;
+   }
+
    static string text;
    text = "";
 
    text += format( IDS_MinimumFrameRate, _renderConfig->MinimumFrameRate ) + "\n";
    text += format( IDS_MaximumFrameRate, _renderConfig->MaximumFrameRate ) + "\n";
-   text += format( IDS_CurrentFrameRate, _clock->GetCurrentFrameRate() ) + "\n";
+   text += format( IDS_CurrentFrameRate, _currentFrameRateCache ) + "\n";
    text += format( IDS_AverageFrameRate, _clock->GetAverageFrameRate() ) + "\n";
    text += format( IDS_TotalFrames, _clock->GetTotalFrameCount() ) + "\n";
    text += format( IDS_LagFrames, _clock->GetLagFrameCount() ) + "\n";

--- a/SFMLGame/DiagnosticsRenderer.h
+++ b/SFMLGame/DiagnosticsRenderer.h
@@ -28,6 +28,9 @@ private:
    std::shared_ptr<sf::Font> _font;
    std::shared_ptr<sf::Text> _text;
    std::shared_ptr<sf::RectangleShape> _background;
+
+   unsigned int _currentFrameRateCache;
+   float _elapsedSeconds;
 };
 
 NAMESPACE_END

--- a/SFMLGame/RenderConfig.cpp
+++ b/SFMLGame/RenderConfig.cpp
@@ -24,6 +24,7 @@ RenderConfig::RenderConfig()
    DiagnosticsCharSize = 24;
    DiagnosticsTextColor = Color::White;
    DiagnosticsBackgroundColor = Color::Blue;
+   DiagnosticsCurrentFrameRateRefreshSeconds = 1.0f;
 
    ArenaBackgroundColor = Color( 48, 48, 48 );
 

--- a/SFMLGame/RenderConfig.h
+++ b/SFMLGame/RenderConfig.h
@@ -28,6 +28,7 @@ public:
    unsigned int DiagnosticsCharSize;
    sf::Color DiagnosticsTextColor;
    sf::Color DiagnosticsBackgroundColor;
+   float DiagnosticsCurrentFrameRateRefreshSeconds;
 
    sf::Color ArenaBackgroundColor;
 


### PR DESCRIPTION
## Overview

It's not really useful for the "current frame rate" portion of the diagnostics view to be refreshing at super-high speed, so this PR dials it down to update only once every second.