### PR TITLE
Bugfix: Pressing keys not bound to buttons shouldn't crash

### DIFF
--- a/SFMLGame/InputStateController.cpp
+++ b/SFMLGame/InputStateController.cpp
@@ -21,20 +21,26 @@ InputStateController::InputStateController( shared_ptr<GameConfig> gameConfig ) 
 
 void InputStateController::KeyPressed( Keyboard::Key key )
 {
-   auto button = _gameConfig->KeyBindingsMap.at( key );
-   auto& buttonState = _buttonStates.at( button );
+   if ( _gameConfig->KeyBindingsMap.contains( key ) )
+   {
+      auto button = _gameConfig->KeyBindingsMap.at( key );
+      auto& buttonState = _buttonStates.at( button );
 
-   buttonState.WasPressed = true;
-   buttonState.IsDown = true;
+      buttonState.WasPressed = true;
+      buttonState.IsDown = true;
+   }
 }
 
 void InputStateController::KeyReleased( Keyboard::Key key )
 {
-   auto button = _gameConfig->KeyBindingsMap.at( key );
-   auto& buttonState = _buttonStates.at( button );
+   if ( _gameConfig->KeyBindingsMap.contains( key ) )
+   {
+      auto button = _gameConfig->KeyBindingsMap.at( key );
+      auto& buttonState = _buttonStates.at( button );
 
-   buttonState.WasPressed = false;
-   buttonState.IsDown = false;
+      buttonState.WasPressed = false;
+      buttonState.IsDown = false;
+   }
 }
 
 void InputStateController::UpdateKeyStates()


### PR DESCRIPTION
## Overview

I can't believe I haven't run into this before, but if you press a key that isn't bound to a button, the whole game crashes. This fixes that by making sure the key that was pressed is bound to a button before trying to process it.